### PR TITLE
Update log option for Prettier on autofmt.lua

### DIFF
--- a/autofmt.lua
+++ b/autofmt.lua
@@ -11,7 +11,7 @@ fmtCommands["c"]      = "clang-format -i"
 fmtCommands["c++"]    = "clang-format -i"
 fmtCommands["csharp"] = "clang-format -i"
 fmtCommands["racket"] = "raco fmt --width 80 --max-blank-lines 2 -i"
-fmtCommands["javascript"] = "prettier --write --loglevel silent"
+fmtCommands["javascript"] = "prettier --write --log-level silent"
 fmtCommands["rust"] = "rustfmt +nightly"
 fmtCommands["go"] = "gofmt -w"
 


### PR DESCRIPTION
Using the `--loglevel` option in the current Prettier versions will return an error message. 

```bash
[warn] Ignored unknown option --loglevel=silent. Did you mean --log-level?
```

Prettier v3.*.* uses `--log-level` instead, as [in the docs](https://prettier.io/docs/cli#--log-level)